### PR TITLE
Bump version, add workaround for Esprima != Acorn ASTs in CFG tests

### DIFF
--- a/cfg/lib/cfg.js
+++ b/cfg/lib/cfg.js
@@ -261,6 +261,8 @@ define(function(require, exports) {
       case 'TryStatement':
         addEdge(stmt, stmt.block.body[0]);
         if(!stmt.finalizer) {
+          // Deal with incompatibility between Esprima and Acorn ASTs
+          if(!stmt.handlers) stmt.handlers = stmt.handler ? [stmt.handler] : [];
           // try-catch
           context[context.length] = { type: 'catch', next: stmt.handlers[0].body.body[0] };
           buildStmtCFG(stmt.block, following, context, accu);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "JS_WALA",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "author": "IBM",
     "contributors": [
       {


### PR DESCRIPTION
The `TryStatement` case here fails because Esprima and Acorn ASTs differ. There is a `stmt.handler` property that needs to be an array in `stmt.handlers`. I ganked this solution from `normalizer/lib/normalizer.js` and applied it here.
